### PR TITLE
Fix premature days helper text condition

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -259,7 +259,7 @@
                 <span class="label-text-alt">in days</span>
               </div>
               <input type="number" class="input input-bordered {error_premature_conception_in_days ? 'input-error' : ''}" bind:value={premature_conception_in_days}/>
-              {#if error_premature_conception_in_weeks}
+              {#if error_premature_conception_in_days}
                 <div class="label">
                   <span class="label-text-alt text-error">Please enter a valid age in days</span>
                 </div>


### PR DESCRIPTION
## Summary
- fix premature birth helper text condition to use the days validation flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0183e02a0832981570530fc57c35c