### PR TITLE
Reset validation errors before form processing

### DIFF
--- a/src/components/weaver_plot.svelte
+++ b/src/components/weaver_plot.svelte
@@ -12,7 +12,7 @@
     export let correct_score;
     export let mother_score;
     export let father_score;
-    // @ts-ignore
+    /** @type {string} */
     export let child_dob;
 
     export let child_age_in_months = 0;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -39,6 +39,13 @@
   function process_form() {
     console.log("Processing form");
     let error = false;
+    error_selected_gender = false;
+    error_child_age_in_months = false;
+    error_child_head_circumference_in_cm = false;
+    error_mother_circumference_in_cm = false;
+    error_father_circumference_in_cm = false;
+    error_premature_conception_in_days = false;
+    error_premature_conception_in_weeks = false;
     if (selected_gender.length == 0) {
       error_selected_gender = true;
       error = true;
@@ -130,6 +137,12 @@
     show_corrected_scores = false;
     selected_gender = "";
     error_selected_gender = false;
+    error_child_age_in_months = false;
+    error_child_head_circumference_in_cm = false;
+    error_mother_circumference_in_cm = false;
+    error_father_circumference_in_cm = false;
+    error_premature_conception_in_days = false;
+    error_premature_conception_in_weeks = false;
     error = "";
     child_age_in_months = 0;
     child_head_circumference_in_cm = 0;


### PR DESCRIPTION
## Summary
- reset all validation booleans before validating form submissions so stale errors do not persist
- clear the validation error flags during form reset to fully clear the UI state
- annotate the exported child_dob prop with a string JSDoc type to satisfy svelte-check

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0183ceb7c8329ba038267b48491e9