### PR TITLE
Handle canceled save when exporting PDF

### DIFF
--- a/src/components/weaver_plot.svelte
+++ b/src/components/weaver_plot.svelte
@@ -12,7 +12,7 @@
     export let correct_score;
     export let mother_score;
     export let father_score;
-    // @ts-ignore
+    /** @type {string | null | undefined} */
     export let child_dob;
 
     export let child_age_in_months = 0;
@@ -69,6 +69,10 @@
           },
         ],
       });
+      if (!path) {
+        console.log("Save dialog cancelled by user");
+        return;
+      }
       const appVersion = await getVersion();
       let result = await invoke("make_pdf", {
         filePath: path,


### PR DESCRIPTION
## Summary
- add a guard in the PDF export flow to exit early when the save dialog is cancelled
- document the expected type of `child_dob` to satisfy svelte-check

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d0183fb638832995fa0ae718d0d91d