### PR TITLE
Handle optional child DOB for PDF generation

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -138,6 +138,12 @@ fn make_pdf(
 
     let template = fs::read_to_string(template_path).expect("Could not read template file.");
 
+    let dob_for_template = if child_dob.trim().is_empty() {
+        None
+    } else {
+        Some(child_dob.trim().to_string())
+    };
+
     let font_files = vec![
         "Roboto-Black.ttf",
         "Roboto-BlackItalic.ttf",
@@ -203,7 +209,7 @@ fn make_pdf(
         mother_score: format!("{:.2}", mom_score),
         parental_average: format!("{:.2}", parental_average),
         version: app_version.to_string(),
-        dob: child_dob.to_string(),
+        dob: dob_for_template.unwrap_or_else(|| "Not provided".to_string()),
     };
     let content = Content { v: c };
 

--- a/src/components/weaver_plot.svelte
+++ b/src/components/weaver_plot.svelte
@@ -70,6 +70,12 @@
         ],
       });
       const appVersion = await getVersion();
+      const dobAsString = typeof child_dob === "string"
+        ? child_dob
+        : child_dob
+          ? String(child_dob)
+          : "";
+
       let result = await invoke("make_pdf", {
         filePath: path,
         childAgeMonths: child_age_in_months,
@@ -79,9 +85,9 @@
         prematureConceptionWeeks: premature_conception_in_weeks,
         prematureConceptionDays: premature_conception_in_days,
         gender: gender,
-        childDob: child_dob,
+        childDob: dobAsString,
         appVersion: appVersion
-        
+
       })
       console.log(result)
 


### PR DESCRIPTION
## Summary
- ensure the child DOB sent from the Weaver plot component is always serialized to a string before invoking the Tauri command
- allow the Tauri `make_pdf` command to treat an empty DOB as "Not provided" so PDF generation succeeds even when no date is supplied

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68d01841fb548329833f3389d4301e40